### PR TITLE
Speed up rotations by caching Pauli matrices

### DIFF
--- a/src/lib/ops.py
+++ b/src/lib/ops.py
@@ -184,6 +184,9 @@ def U1(lam):
                             (0.0, cmath.exp(1j * lam))]))
 
 
+_PAULI_VECTOR = np.array([PauliX(), PauliY(), PauliZ()])
+
+
 # Make a single-qubit rotation operator.
 # This is a simple implementation of the mechanism outlined here:
 # http://www.vcpc.univie.ac.at/~ian/hotlist/qc/talks/bloch-sphere-rotations.pdf
@@ -196,7 +199,7 @@ def Rotation(v, theta):
     raise ValueError('Rotation vector v must be a 3D real unit vector.')
 
   return np.cos(theta / 2) * Identity() - 1j * np.sin(theta / 2) * (
-      v[0] * PauliX() + v[1] * PauliY() + v[2] * PauliZ())
+      np.tensordot(v, pauli_vector, axes=1))
 
 
 def RotationX(theta):

--- a/src/lib/ops.py
+++ b/src/lib/ops.py
@@ -199,7 +199,7 @@ def Rotation(v, theta):
     raise ValueError('Rotation vector v must be a 3D real unit vector.')
 
   return np.cos(theta / 2) * Identity() - 1j * np.sin(theta / 2) * (
-      np.tensordot(v, pauli_vector, axes=1))
+      np.tensordot(v, _PAULI_VECTOR, axes=1))
 
 
 def RotationX(theta):

--- a/src/lib/ops.py
+++ b/src/lib/ops.py
@@ -184,22 +184,26 @@ def U1(lam):
                             (0.0, cmath.exp(1j * lam))]))
 
 
-_PAULI_TENSOR = np.array([PauliX(), PauliY(), PauliZ()])
+# Cache Pauli matrices for performance reasons.
+_PAULI_X = PauliX()
+_PAULI_Y = PauliY()
+_PAULI_Z = PauliZ()
 
 
 # Make a single-qubit rotation operator.
 # This is a simple implementation of the mechanism outlined here:
 # http://www.vcpc.univie.ac.at/~ian/hotlist/qc/talks/bloch-sphere-rotations.pdf
 #        (page 22)
-def Rotation(v, theta):
+def Rotation(v: np.ndarray, theta: float) -> np.ndarray:
   """Produce the single-qubit rotation operator."""
 
-  v = np.array(v)
-  if v.shape != (3,) or abs(v.dot(v) - 1.0) > 1e-8 or not np.all(np.isreal(v)):
+  v = np.asarray(v)
+  if (v.shape != (3,) or not math.isclose(v @ v, 1) or
+      not np.all(np.isreal(v))):
     raise ValueError('Rotation vector v must be a 3D real unit vector.')
 
   return np.cos(theta / 2) * Identity() - 1j * np.sin(theta / 2) * (
-      np.tensordot(v, _PAULI_TENSOR, axes=1))
+      v[0] * _PAULI_X + v[1] * _PAULI_Y + v[2] * _PAULI_Z)
 
 
 def RotationX(theta):

--- a/src/lib/ops.py
+++ b/src/lib/ops.py
@@ -184,7 +184,7 @@ def U1(lam):
                             (0.0, cmath.exp(1j * lam))]))
 
 
-_PAULI_VECTOR = np.array([PauliX(), PauliY(), PauliZ()])
+_PAULI_TENSOR = np.array([PauliX(), PauliY(), PauliZ()])
 
 
 # Make a single-qubit rotation operator.
@@ -199,7 +199,7 @@ def Rotation(v, theta):
     raise ValueError('Rotation vector v must be a 3D real unit vector.')
 
   return np.cos(theta / 2) * Identity() - 1j * np.sin(theta / 2) * (
-      np.tensordot(v, _PAULI_VECTOR, axes=1))
+      np.tensordot(v, _PAULI_TENSOR, axes=1))
 
 
 def RotationX(theta):


### PR DESCRIPTION
Before:
```bash
$ python3 -m timeit -s "from src.lib import ops; import math" "ops.RotationX(math.pi/2)"
5000 loops, best of 5: 44.2 usec per loop
```

After:
```bash
$ python3 -m timeit -s "from src.lib import ops; import math" "ops.RotationX(math.pi/2)"
10000 loops, best of 5: 37.3 usec per loop
```

That's a nice ~15% boost!