### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,6 @@ RUN mkdir -p /home/repro/sources/
 WORKDIR /home/repro/sources/
 RUN git clone https://github.com/qcc4cp/qcc.git
 
-# Update WORKSPACE
-WORKDIR /home/repro/sources/qcc
-RUN sed -i 's/python3.7/python3.9/g' WORKSPACE
-
 # Build qcc
 WORKDIR /home/repro/sources/qcc/src/lib
 RUN bazel build all

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,13 +2,12 @@ new_local_repository(
     name = "third_party_python",
     build_file = "//external:python.BUILD",
     # Configure:
-    path = "/usr/include/python3.11",
+    path = "/usr/include/python3.9",
 )
 
 new_local_repository(
     name = "third_party_numpy",
     build_file = "//external:numpy.BUILD",
     # Configure:
-    # path = "/usr/local/lib/python3.7/dist-packages/numpy/core/",
-    path = "/usr/lib/python3/dist-packages/numpy/core/",
+    path = "/usr/local/lib/python3.9/dist-packages/numpy/_core/",
 )


### PR DESCRIPTION
When building on OS X 14.5 (M1 Pro), `bazel` fails with the following error:

```
#17 50.45 ERROR: /home/repro/sources/qcc/WORKSPACE:1:21: fetching new_local_repository rule //external:third_party_python: java.io.IOException: The repository's path is "/usr/include/python3.11" (absolute: "/usr/include/python3.11") but this directory does not exist.
#17 50.53 ERROR: no such package '@@third_party_python//': The repository's path is "/usr/include/python3.11" (absolute: "/usr/include/python3.11") but this directory does not exist.
#17 50.58 ERROR: /home/repro/sources/qcc/src/lib/BUILD:1:10: //src/lib:libxgates.so depends on @@third_party_python//:python in repository @@third_party_python which failed to fetch. no such package '@@third_party_python//': The repository's path is "/usr/include/python3.11" (absolute: "/usr/include/python3.11") but this directory does not exist.
```

I think the error happens because:
- there's a mismatch between the Python 3.11 in `third_party_python` and the Python 3.9 in `third_party_numpy`,
- the C++ `include` path for `numpy` needs to be updated to the path from `numpy.get_include()`